### PR TITLE
Fix Broken Hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ You can learn more about the arguments you can pass to `main.py` by passing:
 python main.py --help
 ```
 
-In [`/examples/tagging/run_main_1k.sh`](/examples/run_main_1k.sh), we scaled up the initial command line to the whole dataset. Note that we've used the `repo_id` argument to push the dataset to the hub, resulting in [this dataset](https://huggingface.co/datasets/ylacombe/libritts_r_tags).
+In [`/examples/tagging/run_main_1k.sh`](/examples/tagging/run_main_1k.sh), we scaled up the initial command line to the whole dataset. Note that we've used the `repo_id` argument to push the dataset to the hub, resulting in [this dataset](https://huggingface.co/datasets/ylacombe/libritts_r_tags).
 
 The dataset viewer gives an idea of what has been done, namely:
 - new columns were added:


### PR DESCRIPTION
## Summary
This pull request addresses a small issue with a broken hyperlink in the documentation. The link previously pointed to the wrong location. The fix corrects the hyperlink to the intended file path.

## Description of Changes
The broken hyperlink was in the README.md file and referred to `/examples/run_main_1k.sh` instead of the correct path `/examples/tagging/run_main_1k.sh`. This pull request makes the following change:

- Corrected the hyperlink to point to the correct path: 
  - **Before**: [`/examples/tagging/run_main_1k.sh`](/examples/run_main_1k.sh)
  - **After**: [`/examples/tagging/run_main_1k.sh`](/examples/tagging/run_main_1k.sh)

## Additional Information
While creating this PR, I noticed that there are no specific issue or pull request templates in the `.github` directory (no .github folder itself). These templates can help streamline contributions and maintain consistency in reporting issues and creating PRs.

If the maintainers are interested, I'd be happy to create a basic issue and pull request template for the repository. These templates can include sections for bug reports, feature requests, and pull request details, based on common conventions.

Please let me know if you'd like me to proceed with creating these templates or if there's a specific format you'd prefer.

## Review and Feedback
Thank you for reviewing this pull request. I look forward to your feedback and any suggestions for further improvements or changes.
