### PR TITLE
Specify vad_duration variables as float32 to avoid truncation errors

### DIFF
--- a/dataspeech/gpu_enrichments/snr_and_reverb.py
+++ b/dataspeech/gpu_enrichments/snr_and_reverb.py
@@ -46,7 +46,7 @@ def snr_apply(batch, rank=None, audio_column_name="audio", batch_size=32):
             
             snr.append(res["snr"][mask].mean())
             c50.append(res["c50"][mask].mean())
-            vad_durations.append(vad_duration)
+            vad_durations.append(np.float32(vad_duration))
         
         # 16ms window
         batch["snr"] = snr


### PR DESCRIPTION
### File(s) modified
dataspeech/gpu_enrichments/snr_and_reverb.py

### What does this change do?
Fixes issue [#33](https://github.com/huggingface/dataspeech/issues/33), which occurs when the first output of Brouhaha's VAD model is an integer

### Description of changes
- Specify vad_duration variable, extracted by Brouhaha, as an np.float32

### Reviewer
@ylacombe