### PR TITLE
fix: dependency version conflicts in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,19 @@
+# Requires Python <=3.11 (numpy 1.24.4 does not build on Python 3.12+)
+
+# Pin torch/torchaudio — must match a version that torbi ships prebuilt binaries for
+# (2.6, 2.7, or 2.8) and that pyannote.audio 3.3.0 supports
+torch==2.6.0
+torchaudio==2.6.0
+
+# Pin numpy — required by brouhaha-vad (pinned to ==1.24.4)
+numpy==1.24.4
+
+# Pin scipy/scikit-learn/torchmetrics to versions compatible with numpy 1.24
+scipy<1.12
+scikit-learn<1.4
+torchmetrics<1.3
+
+# Direct dependencies
 datasets[audio]
 https://github.com/marianne-m/brouhaha-vad/archive/main.zip
 penn


### PR DESCRIPTION
## Summary         

  - Pin torch, torchaudio, numpy, scipy, scikit-learn, and torchmetrics to versions that are mutually compatible

## Problem

  Even with Python <=3.11, pip install -r requirements.txt fails due to cascading version conflicts:

  1. brouhaha-vad internally pins numpy==1.24.4, but the latest scipy (>=1.12), scikit-learn (>=1.4), and torchmetrics (>=1.3) all require numpy>=1.26
  2. torbi (transitive dep of penn) only ships prebuilt binaries for torch 2.6/2.7/2.8,  installing without a torch pin pulls in an incompatible version
  3. pyannote.audio==3.3.0 (required by brouhaha-vad) uses torchaudio.AudioMetaData, which was removed in recent torchaudio versions

  Without pins, pip resolves to the latest versions of these packages, which are incompatible with each other.